### PR TITLE
[Bug fix] SQLDatabaseChain not return sql query even if return_direct=True

### DIFF
--- a/langchain/chains/sql_database/base.py
+++ b/langchain/chains/sql_database/base.py
@@ -158,7 +158,7 @@ class SQLDatabaseChain(Chain):
             # the result of the sql query result, otherwise try to get a human readable
             # final answer
             if self.return_direct:
-                final_result = result
+                final_result = sql_cmd
             else:
                 _run_manager.on_text("\nAnswer:", verbose=self.verbose)
                 input_text += f"{sql_cmd}\nSQLResult: {result}\nAnswer:"


### PR DESCRIPTION
 

 - Description: SQLDatabaseChain not return sql query even if return_direct=True
  - Issue:

for SQLDatabaseChain, although its parameter set to return_direct=True, it still returns results (e.g., USB wire 98,  Laptop 90, Desktop 86, ....)  instead of sql query (e.g., SELECT name AS "Product Category" FROM category ORDER BY category_id LIMIT 10;)

I found that it's because `final_result` variable is wrongly set to `result` variable instead of `sql_cmd` if self.return_direct = True

Hope my pull request will be accepted. Thanks.

  - Dependencies: No, as it's just a simple fix by replacing a variable

See contribution guidelines for more information on how to write/run tests, lint, etc: https://github.com/hwchase17/langchain/blob/master/.github/CONTRIBUTING.md
